### PR TITLE
Add project README and architecture documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Patient Management System
+
+This repository contains a Spring Boot–based microservice architecture for a Patient Management System (PMS). Each service focuses on a specific domain and communicates through standard REST or gRPC interfaces.
+
+## Services
+
+- **api-gateway** – Routes external requests to the underlying services.
+- **auth-service** – Provides authentication and authorization using Spring Security and JWT.
+- **billing-service** – Manages patient billing and payments.
+- **patient-service** – Handles patient records and related operations.
+- **analytics-service** – Processes and reports analytical data.
+
+## Development
+
+Each microservice is an independent Maven project. Use the included Maven wrapper to build and test services.
+
+```bash
+cd <service-name>
+./mvnw test
+```
+
+Tests are run per service; ensure they all pass before committing changes.
+
+## Documentation
+
+Additional documentation is available in the [`docs/`](docs/) directory.
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,23 @@
+# Architecture Overview
+
+The Patient Management System is composed of several Spring Boot microservices. Each service is designed to be self-contained and focused on a specific area of the domain.
+
+## Services
+
+- **api-gateway**: Central entry point for clients. It forwards HTTP requests to the appropriate backend service.
+- **auth-service**: Manages user authentication and authorization, issuing and validating JWT tokens.
+- **billing-service**: Tracks invoices and processes payments for patient treatments.
+- **patient-service**: Stores and serves patient profiles and related data.
+- **analytics-service**: Aggregates information from other services to provide reporting and insights.
+
+## Development Notes
+
+- Each service includes a Maven wrapper (`mvnw`) for consistent builds.
+- Services communicate primarily through REST; `grpc-requests` contains sample gRPC interactions.
+- To build or test a service:
+
+```bash
+cd <service-name>
+./mvnw test
+```
+


### PR DESCRIPTION
## Summary
- Add root README outlining available microservices and development guidelines
- Provide architecture documentation describing each service and how to run tests

## Testing
- `mvn test` *(analytics-service)* — failed: Non-resolvable parent POM (network is unreachable)
- `mvn test` *(auth-service)* — failed: Non-resolvable parent POM (network is unreachable)


------
https://chatgpt.com/codex/tasks/task_e_68bb1c13aa848320af57bfe8af272ffb